### PR TITLE
Add personal website for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Avinash Kothapalli - Personal Website
+
+This repository contains the source for my personal website. The site highlights my professional experience, projects and links to my resume.
+
+To view the site locally, open `index.html` in a web browser. You can also serve it with any static file server if you prefer.
+
+To publish the site with GitHub Pages:
+
+1. Push the contents of this repository to GitHub.
+2. In the repository settings, enable GitHub Pages and choose the `main` branch as the source.
+3. The site will be available at `https://<your-username>.github.io/<repository-name>/`.
+
+Feel free to customize the content or styling to keep the site up to date.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Avinash Kothapalli</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Avinash Kothapalli</h1>
+    <p>Senior Software Developer</p>
+    <nav>
+      <a href="#about">About</a> |
+      <a href="#experience">Experience</a> |
+      <a href="#projects">Projects</a> |
+      <a href="#contact">Contact</a> |
+      <a href="Resume_AvinashKothapalli.pdf">Resume</a>
+    </nav>
+  </header>
+
+  <section id="about">
+    <h2>About</h2>
+    <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
+    <p>Recently I have focused on applying AI and LLMs in the networking domain, building tools that streamline operations and enable autonomous networks.</p>
+  </section>
+
+  <section id="experience">
+    <h2>Experience</h2>
+    <h3>Nokia – Senior Delivery Software Engineer (2020–Present)</h3>
+    <ul>
+      <li>Develop custom network software solutions for service providers and enterprises.</li>
+      <li>Create API interfaces for service provisioning, life-cycle management, un-provisioning and debugging using YANG Models and REST.</li>
+      <li>Provide solutions to automate network service deployment based on customer network configuration and OSS system requirements.</li>
+      <li>Deploy custom scripts written in JavaScript and Python utilizing Nokia's NSP applications framework for workflow management, service discovery and deployment.</li>
+      <li>Guide junior team members and interns.</li>
+      <li>Built a log analysis tool leveraging the NSP workflow manager and large language models to accelerate troubleshooting.</li>
+      <li>Worked on autonomous networks and intent-based service deployment using Pydantic and LLaMA AI models.</li>
+    </ul>
+  </section>
+
+  <section id="projects">
+    <h2>Projects</h2>
+    <ul>
+      <li><strong>AI Log Analysis Tool:</strong> Designed a tool that integrates the NSP workflow manager with large language models to parse and analyze network logs.</li>
+      <li><strong>Intent-Based Service Deployment:</strong> Automated network service provisioning using Pydantic schemas and LLaMA models to interpret user intent.</li>
+    </ul>
+  </section>
+
+  <section id="contact">
+    <h2>Contact</h2>
+    <p>Email: <a href="mailto:avinashvkothapalli@gmail.com">avinashvkothapalli@gmail.com</a></p>
+    <p>GitHub: <a href="https://github.com/avinash040">github.com/avinash040</a></p>
+    <p>LinkedIn: <a href="https://linkedin.com/in/avinash040">linkedin.com/in/avinash040</a></p>
+  </section>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,38 @@
+body {
+  font-family: Arial, sans-serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0;
+  color: #333;
+}
+
+header {
+  background: #f5f5f5;
+  padding: 20px;
+  text-align: center;
+}
+
+nav a {
+  margin: 0 10px;
+  color: #333;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+section {
+  padding: 20px;
+  max-width: 800px;
+  margin: auto;
+}
+
+ul {
+  list-style-type: disc;
+  padding-left: 20px;
+}
+
+footer {
+  background: #f5f5f5;
+  text-align: center;
+  padding: 10px;
+  margin-top: 40px;
+}


### PR DESCRIPTION
## Summary
- Add `index.html` personal website featuring work experience, AI/LLM projects, and contact info
- Style the site with a simple `styles.css`
- Include `README.md` with instructions for enabling GitHub Pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6266765148325920ff8d13c754e92