### PR TITLE
Create dynamic personal website

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,52 +12,93 @@
     <nav>
       <a href="#about">About</a> |
       <a href="#experience">Experience</a> |
+      <a href="#skills">Skills</a> |
       <a href="#projects">Projects</a> |
       <a href="#contact">Contact</a> |
-      <a href="Resume_AvinashKothapalli.pdf">Resume</a>
+      <a href="#resume">Resume</a>
+      <button id="theme-toggle">Toggle Theme</button>
     </nav>
   </header>
 
-  <section id="about">
-    <h2>About</h2>
-    <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
-    <p>Recently I have focused on applying AI and LLMs in the networking domain, building tools that streamline operations and enable autonomous networks.</p>
-  </section>
+  <main>
+    <section id="about">
+      <h2>About</h2>
+      <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
+      <p>Recently I have focused on applying AI and LLMs in the networking domain, building tools that streamline operations and enable autonomous networks.</p>
+    </section>
 
-  <section id="experience">
-    <h2>Experience</h2>
-    <h3>Nokia – Senior Delivery Software Engineer (2020–Present)</h3>
-    <ul>
-      <li>Develop custom network software solutions for service providers and enterprises.</li>
-      <li>Create API interfaces for service provisioning, life-cycle management, un-provisioning and debugging using YANG Models and REST.</li>
-      <li>Provide solutions to automate network service deployment based on customer network configuration and OSS system requirements.</li>
-      <li>Deploy custom scripts written in JavaScript and Python utilizing Nokia's NSP applications framework for workflow management, service discovery and deployment.</li>
-      <li>Guide junior team members and interns.</li>
-      <li>Built a log analysis tool leveraging the NSP workflow manager and large language models to accelerate troubleshooting.</li>
-      <li>Worked on autonomous networks and intent-based service deployment using Pydantic and LLaMA AI models.</li>
-    </ul>
-  </section>
+    <section id="experience">
+      <h2>Experience</h2>
+      <article>
+        <h3>Nokia – Senior Delivery Software Engineer (2020–Present)</h3>
+        <ul>
+          <li>Develop custom network software solutions for service providers and enterprises.</li>
+          <li>Create API interfaces for service provisioning, life-cycle management, un-provisioning and debugging using YANG Models and REST.</li>
+          <li>Provide solutions to automate network service deployment based on customer network configuration and OSS system requirements.</li>
+          <li>Deploy custom scripts written in JavaScript and Python utilizing Nokia's NSP applications framework for workflow management, service discovery and deployment.</li>
+          <li>Guide junior team members and interns.</li>
+          <li>Built a log analysis tool leveraging the NSP workflow manager and large language models to accelerate troubleshooting.</li>
+          <li>Worked on autonomous networks and intent-based service deployment using Pydantic and LLaMA AI models.</li>
+        </ul>
+      </article>
+      <article>
+        <h3>VMware – Member of Technical Staff II (2016–2020)</h3>
+        <ul>
+          <li>Converted the Smarts Alerting Engine into a microservices architecture using Kubernetes, Kafka and gRPC.</li>
+          <li>Developed Python-based high performance data collectors and Velocloud SD-WAN network simulators.</li>
+          <li>Created prototype Angular frontend UIs and evaluated Kafka Streams and Flink for KPI metric processing.</li>
+        </ul>
+      </article>
+      <article>
+        <h3>Cisco Systems – Software Engineer (2012–2016)</h3>
+        <ul>
+          <li>Implemented MPLS TP performance management and linear protection features for IOS/XR.</li>
+          <li>Contributed to EVPN, VPWS, VPLS, L2TPv3 and L2 bridge domain development.</li>
+          <li>Maintained private cloud infrastructure using Cisco UCS servers with vSphere and OpenStack.</li>
+        </ul>
+      </article>
+      <article>
+        <h3>Blackberry – Software Designer / Protocol Associate (Co-op) (2010–2011)</h3>
+        <ul>
+          <li>Developed features for Blackberry device radio and OS modules in C and Java.</li>
+          <li>Analyzed wireless protocol performance.</li>
+        </ul>
+      </article>
+    </section>
 
-  <section id="projects">
-    <h2>Projects</h2>
-    <ul>
-      <li><strong>AI Log Analysis Tool:</strong> Designed a tool that integrates the NSP workflow manager with large language models to parse and analyze network logs.</li>
-      <li><strong>Intent-Based Service Deployment:</strong> Automated network service provisioning using Pydantic schemas and LLaMA models to interpret user intent.</li>
-    </ul>
-  </section>
+    <section id="skills">
+      <h2>Skills</h2>
+      <ul>
+        <li><strong>Languages:</strong> Python, JavaScript, Java, C, C++</li>
+        <li><strong>Core Technologies:</strong> Distributed Systems, SDN/SD-WAN, Networking Protocols, VMware/OpenStack, Microservices, Serverless computing, Information Centric Networking</li>
+        <li><strong>API Protocols:</strong> REST, YANG/RESTCONF, gRPC, Kafka, Kafka Streams, SOAP</li>
+        <li><strong>CI/CD:</strong> Docker, Kubernetes, AWS, Jenkins, Git, VS Code</li>
+        <li><strong>Supplemental:</strong> Game Dev (UE4, Jmonkey, Blender), ML (GPT-3, Harmonai)</li>
+      </ul>
+    </section>
 
-  <section id="contact">
-    <h2>Contact</h2>
-    <p>Email: <a href="mailto:avinashvkothapalli@gmail.com">avinashvkothapalli@gmail.com</a></p>
-    <p>GitHub: <a href="https://github.com/avinash040">github.com/avinash040</a></p>
-    <p>LinkedIn: <a href="https://linkedin.com/in/avinash040">linkedin.com/in/avinash040</a></p>
-  </section>
+    <section id="projects">
+      <h2>Projects</h2>
+      <div id="projects-list"></div>
+    </section>
+
+    <section id="contact">
+      <h2>Contact</h2>
+      <p>Email: <a href="mailto:avinashvkothapalli@gmail.com">avinashvkothapalli@gmail.com</a></p>
+      <p>GitHub: <a href="https://github.com/avinash040">github.com/avinash040</a></p>
+      <p>LinkedIn: <a href="https://linkedin.com/in/avinash040">linkedin.com/in/avinash040</a></p>
+    </section>
+
+    <section id="resume">
+      <h2>Resume</h2>
+      <button id="resume-toggle">Show Resume</button>
+      <iframe id="resume-frame" src="Resume_AvinashKothapalli.pdf"></iframe>
+    </section>
+  </main>
 
   <footer>
     <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
-    <script>
-      document.getElementById('year').textContent = new Date().getFullYear();
-    </script>
   </footer>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // dynamic project list
+  const projects = [
+    {
+      title: 'AI Log Analysis Tool',
+      description: 'Designed a tool that integrates the NSP workflow manager with large language models to parse and analyze network logs.'
+    },
+    {
+      title: 'Intent-Based Service Deployment',
+      description: 'Automated network service provisioning using Pydantic schemas and LLaMA models to interpret user intent.'
+    }
+  ];
+
+  const list = document.getElementById('projects-list');
+  projects.forEach(p => {
+    const div = document.createElement('div');
+    div.className = 'project';
+    div.innerHTML = `<h3>${p.title}</h3><p>${p.description}</p>`;
+    list.appendChild(div);
+  });
+
+  // theme toggle
+  const toggle = document.getElementById('theme-toggle');
+  const currentTheme = localStorage.getItem('theme');
+  if (currentTheme === 'dark') {
+    document.body.classList.add('dark');
+  }
+
+  toggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark');
+    localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+  });
+
+  // resume toggle
+  const resumeBtn = document.getElementById('resume-toggle');
+  const resumeFrame = document.getElementById('resume-frame');
+  resumeBtn.addEventListener('click', () => {
+    resumeFrame.classList.toggle('show');
+    resumeBtn.textContent = resumeFrame.classList.contains('show') ? 'Hide Resume' : 'Show Resume';
+  });
+
+  // set footer year
+  document.getElementById('year').textContent = new Date().getFullYear();
+});

--- a/styles.css
+++ b/styles.css
@@ -1,38 +1,74 @@
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   margin: 0;
   padding: 0;
   color: #333;
+  background: #fff;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+body.dark {
+  background: #121212;
+  color: #eee;
 }
 
 header {
-  background: #f5f5f5;
+  background: #333;
+  color: #fff;
   padding: 20px;
   text-align: center;
 }
 
 nav a {
   margin: 0 10px;
-  color: #333;
+  color: #fff;
   text-decoration: none;
   font-weight: bold;
 }
 
+nav button {
+  margin-left: 20px;
+  padding: 5px 10px;
+}
+
 section {
   padding: 20px;
-  max-width: 800px;
+  max-width: 900px;
   margin: auto;
 }
 
-ul {
-  list-style-type: disc;
-  padding-left: 20px;
+#projects-list .project {
+  margin-bottom: 15px;
+}
+
+#resume-frame {
+  width: 100%;
+  height: 600px;
+  border: none;
+  display: none;
+}
+
+#resume-frame.show {
+  display: block;
 }
 
 footer {
-  background: #f5f5f5;
+  background: #333;
+  color: #fff;
   text-align: center;
   padding: 10px;
   margin-top: 40px;
+}
+
+body.dark header {
+  background: #222;
+}
+
+body.dark nav a {
+  color: #eee;
+}
+
+body.dark footer {
+  background: #222;
 }


### PR DESCRIPTION
## Summary
- Revamp personal website with detailed experience, skills, and resume viewer
- Add dynamic projects rendering and dark mode toggle via JavaScript
- Introduce responsive styling with dark theme support

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -s http://localhost:8000/index.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a627fe29f08325a009c9041e679dd4