### PR TITLE
Add VMware experience subpages

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,17 @@
           <li>Researched and evaluated Kafka Streams & Apache Flink for KPI metric processing.</li>
           <li>Managed Nokia ASAM and VMware SAS certification for British Telecom.</li>
         </ul>
+        <p>Explore more:</p>
+        <ul class="vmware-links">
+          <li><a href="vmware/java.html">Java projects</a></li>
+          <li><a href="vmware/python.html">Python projects</a></li>
+          <li><a href="vmware/docker.html">Docker</a></li>
+          <li><a href="vmware/kafka.html">Kafka</a></li>
+          <li><a href="vmware/aws.html">AWS</a></li>
+          <li><a href="vmware/angular.html">Angular</a></li>
+          <li><a href="vmware/kubernetes.html">Kubernetes</a></li>
+          <li><a href="vmware/jenkins.html">Jenkins</a></li>
+        </ul>
       </article>
       <article>
         <h3>Software Engineer – Cisco Systems</h3>

--- a/vmware/angular.html
+++ b/vmware/angular.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VMware – Angular</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <h1>VMware: Angular UI</h1>
+    <nav><a href="../index.html#experience">&larr; Back to Experience</a></nav>
+  </header>
+  <main>
+    <section>
+      <p>Designed the project's web UI using Balsamiq wireframes and implemented it with Angular. Leveraged VMware's <a href="https://clarity.design/">Clarity Design</a> framework for consistent styling and components.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/vmware/aws.html
+++ b/vmware/aws.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VMware – AWS</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <h1>VMware: AWS Deployment</h1>
+    <nav><a href="../index.html#experience">&larr; Back to Experience</a></nav>
+  </header>
+  <main>
+    <section>
+      <p>Took ownership of the Nokia ASAM and SMARTS certification for British Telecom, deploying SMARTS infrastructure on AWS. Utilized S3 storage and multiple EC2 instances, gaining hands-on experience with networking setup and other AWS features.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/vmware/docker.html
+++ b/vmware/docker.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VMware – Docker</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <h1>VMware: Docker Experience</h1>
+    <nav><a href="../index.html#experience">&larr; Back to Experience</a></nav>
+  </header>
+  <main>
+    <section>
+      <p>Containerized Java-based data collectors using Docker, initially orchestrated with Docker Compose. Gained deep insights into Docker networking and persistent storage both on disk and within MongoDB. Also established a local Docker registry for the team using Artifactory.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/vmware/java.html
+++ b/vmware/java.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VMware – Java Projects</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <h1>VMware: Java Projects</h1>
+    <nav><a href="../index.html#experience">&larr; Back to Experience</a></nav>
+  </header>
+  <main>
+    <section>
+      <h2>Alerting Engine</h2>
+      <p>I implemented the Alerting Engine component of VMware's SMARTS root cause analysis platform. Configuration was loaded from YAML files, templates were defined in JSON, and REST schemas were built using Swagger. The alert processing pipeline first leveraged Kafka Streams before transitioning to Apache Flink.</p>
+    </section>
+    <section>
+      <h2>Velocloud Data Collector</h2>
+      <p>Developed a REST-based data collector that ingests metrics from the Velocloud SD-WAN solution and feeds them into SMARTS. The work involved mastering SD-WAN concepts and defining thresholds and alarms that map to orchestrator data.</p>
+    </section>
+    <section>
+      <h2>Kafka Connector</h2>
+      <p>Implemented a Kafka connector interface enabling SMARTS to interact seamlessly with Kafka as part of the alerting infrastructure.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/vmware/jenkins.html
+++ b/vmware/jenkins.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VMware – Jenkins</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <h1>VMware: Jenkins CI/CD</h1>
+    <nav><a href="../index.html#experience">&larr; Back to Experience</a></nav>
+  </header>
+  <main>
+    <section>
+      <p>Set up the Jenkins CI/CD environment for the Alerting and Data Collection framework projects. Authored the Gradle-based build script for the Alerting component.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/vmware/kafka.html
+++ b/vmware/kafka.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VMware – Kafka</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <h1>VMware: Kafka Work</h1>
+    <nav><a href="../index.html#experience">&larr; Back to Experience</a></nav>
+  </header>
+  <main>
+    <section>
+      <p>Used Kafka as the central message bus across distributed components. Developed alerting engine data processing with the Kafka Streams DSL and authored a Kafka adapter library to streamline integration with SMARTS.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/vmware/kubernetes.html
+++ b/vmware/kubernetes.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VMware – Kubernetes</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <h1>VMware: Kubernetes</h1>
+    <nav><a href="../index.html#experience">&larr; Back to Experience</a></nav>
+  </header>
+  <main>
+    <section>
+      <p>Orchestrated the Data Collection Controller and associated collectors using Kubernetes. Gained experience with Minikube configuration, networking, and storage management.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/vmware/python.html
+++ b/vmware/python.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VMware – Python Projects</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+  <header>
+    <h1>VMware: Python Projects</h1>
+    <nav><a href="../index.html#experience">&larr; Back to Experience</a></nav>
+  </header>
+  <main>
+    <section>
+      <h2>Velocloud Simulator</h2>
+      <p>Built a simulator to replicate complex Velocloud SD-WAN topologies based on API specifications. The simulator serialized existing setups and emulated them using the Python Connexion library with a Flask-driven REST interface.</p>
+    </section>
+    <section>
+      <h2>Data Collection Controller</h2>
+      <p>Created a Python and Flask-based orchestrator managing containerized data collectors with MongoDB for state. Deployment was handled through Kubernetes for scalable operation.</p>
+    </section>
+    <section>
+      <h2>Unit Tests and Scripts</h2>
+      <p>Authored numerous utility scripts and unit-testing helpers throughout my career, including an OpenCV-based face recognition tool.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link new detailed subpages for the VMware role covering Java, Python, Docker, Kafka, AWS, Angular, Kubernetes, and Jenkins
- each subpage highlights specific projects and responsibilities

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e415cb688325a7bb80cf48e3acc8