### PR TITLE
chore: add RAG index builder workflow

### DIFF
--- a/.github/workflows/build-rag-index.yml
+++ b/.github/workflows/build-rag-index.yml
@@ -1,0 +1,122 @@
+name: Build RAG Index
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      FILE_GLOBS: |
+        README.md
+        docs/**/*.md
+        **/*.md
+        **/*.txt
+      EXCLUDE_GLOBS: |
+        **/node_modules/**
+        **/dist/**
+        **/*.png
+        **/*.jpg
+        **/*.pdf
+        **/.git/**
+        **/*.min.js
+      CHUNK_CHARS: 1400
+      CHUNK_OVERLAP: 200
+      OUTPUT_DIR: data
+      OUTPUT_FILE: vectors.json
+      MODEL_NAME: sentence-transformers/all-MiniLM-L6-v2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sentence-transformers tqdm pathspec
+      - name: Build index
+        run: |
+          python - <<'PY'
+import os, json, hashlib, pathlib
+from sentence_transformers import SentenceTransformer
+from tqdm import tqdm
+from pathspec import PathSpec
+from pathspec.patterns import GitWildMatchPattern
+
+file_globs = os.environ['FILE_GLOBS'].splitlines()
+exclude_globs = os.environ['EXCLUDE_GLOBS'].splitlines()
+chunk_chars = int(os.environ['CHUNK_CHARS'])
+chunk_overlap = int(os.environ['CHUNK_OVERLAP'])
+output_dir = pathlib.Path(os.environ['OUTPUT_DIR'])
+output_file = os.environ['OUTPUT_FILE']
+model_name = os.environ['MODEL_NAME']
+
+spec = PathSpec.from_lines(GitWildMatchPattern, exclude_globs)
+paths = set()
+for pattern in file_globs:
+    paths.update(pathlib.Path('.').glob(pattern))
+files = [p for p in paths if p.is_file() and not spec.match_file(str(p))]
+valid_files = []
+for path in files:
+    try:
+        with open(path, 'rb') as f:
+            if b'\x00' in f.read(1024):
+                continue
+        valid_files.append(path)
+    except Exception:
+        continue
+
+chunks = []
+
+def chunk_text(text):
+    chunks = []
+    start = 0
+    length = len(text)
+    while start < length:
+        end = min(length, start + chunk_chars)
+        split = text.rfind('\n\n', start, end)
+        if split == -1 or split <= start + chunk_chars // 2:
+            split = end
+        chunk = text[start:split]
+        if chunk.strip():
+            chunks.append(chunk.strip())
+        if split == length:
+            break
+        start = max(0, split - chunk_overlap)
+    return chunks
+
+for path in valid_files:
+    text = path.read_text(encoding='utf-8', errors='ignore')
+    for chunk in chunk_text(text):
+        cid = hashlib.sha256(f"{path}:{len(chunks)}".encode()).hexdigest()
+        chunks.append({'id': cid, 'text': chunk, 'source': str(path)})
+
+embeddings = []
+if chunks:
+    model = SentenceTransformer(model_name)
+    texts = [c['text'] for c in chunks]
+    embeddings = model.encode(texts, normalize_embeddings=True, show_progress_bar=True)
+    for rec, emb in zip(chunks, embeddings):
+        rec['embedding'] = emb.tolist()
+
+output_dir.mkdir(parents=True, exist_ok=True)
+out_path = output_dir / output_file
+with open(out_path, 'w', encoding='utf-8') as f:
+    json.dump(chunks, f)
+size_kb = out_path.stat().st_size / 1024
+print(f'Total chunks: {len(chunks)}')
+print(f'File size (KB): {size_kb:.2f}')
+PY
+      - name: Commit vectors
+        run: |
+          if git diff --quiet --exit-code ${{ env.OUTPUT_DIR }}/${{ env.OUTPUT_FILE }}; then
+            echo "No changes to commit"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add ${{ env.OUTPUT_DIR }}/${{ env.OUTPUT_FILE }}
+            git commit -m "chore: update RAG index"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and commit a MiniLM-based RAG index

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a93d964b2c8325abb8d7fdb1b4db9d