### PR TITLE
fix: allow workflow to push vectors

### DIFF
--- a/.github/workflows/build-rag-index.yml
+++ b/.github/workflows/build-rag-index.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     env:
       FILE_GLOBS: |


### PR DESCRIPTION
## Summary
- grant contents: write permission to Build RAG Index workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a941c8ce8c83258d699d2a93640f69