### PR TITLE
Add Cloudflare Worker and chat UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8">
   <title>Avinash Kothapalli</title>
   <link rel="stylesheet" href="styles.css">
+  <style>
+    #chat-container { max-width: 600px; margin: 2rem auto; }
+    #chat-log { border: 1px solid #ccc; padding: 1rem; height: 300px; overflow-y: auto; background: #fafafa; }
+    .message { padding: .5rem; border-radius: 4px; margin-bottom: .5rem; }
+    .message.user { background: #e0f7fa; }
+    .message.bot { background: #f1f8e9; }
+    .message.sources { background: #fff; font-size: 0.8rem; color: #555; }
+    #chat-form { display: flex; gap: .5rem; margin-top: 1rem; }
+    #chat-input { flex: 1; }
+  </style>
 </head>
 <body>
   <header>
@@ -23,6 +33,17 @@
   </header>
 
   <main>
+    <section id="chat">
+      <h2>Chat</h2>
+      <div id="chat-container">
+        <div id="chat-log"></div>
+        <form id="chat-form">
+          <input id="chat-input" type="text" placeholder="Ask a question..." />
+          <button type="submit">Send</button>
+        </form>
+      </div>
+    </section>
+
     <section id="about">
       <h2>About</h2>
       <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
@@ -162,5 +183,47 @@
     <p>&copy; <span id="year"></span> Avinash Kothapalli</p>
   </footer>
   <script src="script.js"></script>
+  <script>
+    const WORKER_URL = 'https://repo-chat-api.example.workers.dev'; // replace with your Worker URL
+
+    const log = document.getElementById('chat-log');
+    const form = document.getElementById('chat-form');
+    const input = document.getElementById('chat-input');
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const text = input.value.trim();
+      if (!text) return;
+      appendMessage('user', text);
+      input.value = '';
+      try {
+        const res = await fetch(`${WORKER_URL}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: text })
+        });
+        const data = await res.json();
+        if (data.answer) {
+          appendMessage('bot', data.answer);
+          if (data.sources) {
+            const src = data.sources.map(s => `${s.label} • ${s.path} (${s.score.toFixed(2)})`).join(', ');
+            appendMessage('bot', `Sources: ${src}`, 'sources');
+          }
+        } else if (data.error) {
+          appendMessage('bot', data.error);
+        }
+      } catch (err) {
+        appendMessage('bot', 'Error: ' + err.message);
+      }
+    });
+
+    function appendMessage(role, text, extra = '') {
+      const div = document.createElement('div');
+      div.className = `message ${role} ${extra}`;
+      div.textContent = text;
+      log.appendChild(div);
+      log.scrollTop = log.scrollHeight;
+    }
+  </script>
 </body>
 </html>

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1,0 +1,104 @@
+import { pipeline } from "@xenova/transformers";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function jsonResponse(data, init = {}) {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...corsHeaders, ...(init.headers || {}) },
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders });
+    }
+
+    if (url.pathname !== "/api/chat" || request.method !== "POST") {
+      return jsonResponse({ error: "not_found" }, { status: 404 });
+    }
+
+    let input;
+    try {
+      input = await request.json();
+    } catch (_) {
+      return jsonResponse({ error: "invalid_json" }, { status: 400 });
+    }
+
+    if (!input?.message || typeof input.message !== "string") {
+      return jsonResponse({ error: "missing_message" }, { status: 400 });
+    }
+
+    try {
+      const topK = parseInt(env.TOP_K || "5", 10);
+      const maxChars = parseInt(env.MAX_CONTEXT_CHARS || "6000", 10);
+
+      // Fetch index
+      const indexRes = await fetch(env.VECTORS_URL);
+      if (!indexRes.ok) {
+        throw new Error(`vectors fetch failed: ${indexRes.status}`);
+      }
+      const index = await indexRes.json();
+
+      // Embed query
+      const embedder = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2");
+      const qEmbed = await embedder(input.message, { pooling: "mean", normalize: true });
+      const q = Array.from(qEmbed.data);
+
+      const l2 = (arr) => Math.sqrt(arr.reduce((s, v) => s + v * v, 0));
+
+      const scored = index.map((item, idx) => {
+        const emb = item.embedding;
+        const norm = l2(emb);
+        const score = emb.reduce((s, v, i) => s + v * q[i], 0) / norm; // query already normalized
+        return { ...item, score, label: `#${idx + 1}` };
+      });
+
+      scored.sort((a, b) => b.score - a.score);
+      const top = scored.slice(0, topK);
+
+      let context = "";
+      const sources = [];
+      for (let i = 0; i < top.length; i++) {
+        const r = top[i];
+        const chunk = `[#${i + 1} • ${r.source}]\n${r.text}\n\n`;
+        if ((context + chunk).length > maxChars) break;
+        context += chunk;
+        sources.push({ label: `#${i + 1}`, path: r.source, score: r.score });
+      }
+
+      const system =
+        "Answer strictly from the provided repository context. If the answer isn’t in the context, say you don’t know. Always cite sources inline like [#n • path].";
+      const prompt = `${system}\n\nContext:\n${context}\nUser: ${input.message}`;
+
+      const geminiRes = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${env.GEMINI_MODEL}:generateContent?key=${env.GEMINI_API_KEY}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }],
+            generationConfig: { temperature: 0.2, maxOutputTokens: 1000 },
+          }),
+        }
+      );
+
+      if (!geminiRes.ok) {
+        throw new Error(await geminiRes.text());
+      }
+      const geminiData = await geminiRes.json();
+      const answer = geminiData.candidates?.[0]?.content?.parts?.[0]?.text || "";
+
+      return jsonResponse({ answer, sources });
+    } catch (err) {
+      return jsonResponse({ error: "internal_error", detail: err.message }, { status: 500 });
+    }
+  },
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,9 @@
+name = "repo-chat-api"
+main = "worker.js"
+compatibility_date = "2025-08-23"
+
+[vars]
+VECTORS_URL = "https://avinash040.github.io/Home/data/vectors.json"
+GEMINI_MODEL = "gemini-2.5-flash"
+TOP_K = "5"
+MAX_CONTEXT_CHARS = "6000"


### PR DESCRIPTION
## Summary
- add Cloudflare Worker with retrieval + Gemini chat endpoint
- expose repo vectors and model info via wrangler config vars
- embed chat interface on index page that calls the Worker and lists sources

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a94d454f68832598d565d9ca0e3627