### PR TITLE
Document Gemini API key setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore local development secrets
+worker/.dev.vars

--- a/README.md
+++ b/README.md
@@ -11,3 +11,25 @@ To publish the site with GitHub Pages:
 3. The site will be available at `https://<your-username>.github.io/<repository-name>/`.
 
 Feel free to customize the content or styling to keep the site up to date.
+
+## Worker API
+
+The `worker` directory contains a Cloudflare Worker that backs the `/api/chat` endpoint. It is configured by the `wrangler.toml` file at the repository root, which points to `worker/worker.js` and reads your Gemini API key from the `GEMINI_API_KEY` environment variable.
+
+For local development:
+
+1. Copy `worker/.dev.vars.example` to `worker/.dev.vars`.
+2. Set `GEMINI_API_KEY` in that file.
+3. Run `npx wrangler dev` from the repository root.
+
+For deployment on Cloudflare, store the key as a secret:
+
+```sh
+wrangler secret put GEMINI_API_KEY
+```
+
+Then deploy the worker from the repository root:
+
+```sh
+npx wrangler deploy
+```

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -1,0 +1,2 @@
+# Rename this file to .dev.vars and fill in your secret for local development.
+GEMINI_API_KEY="your_gemini_api_key"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "repo-chat-api"
-main = "worker.js"
+main = "worker/worker.js"
 compatibility_date = "2025-08-23"
 
 [vars]


### PR DESCRIPTION
## Summary
- move `wrangler.toml` to repo root and point it at `worker/worker.js` so wrangler finds the entry point
- update README with root-level wrangler dev/deploy instructions
- keep local secrets out of version control with `.dev.vars` example and .gitignore

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a95356abc883258381fe242b0ae938