### PR TITLE
Fix transformer initialization for Cloudflare Workers

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1,4 +1,12 @@
-import { pipeline } from "@xenova/transformers";
+import { pipeline, env } from "@xenova/transformers";
+
+// Configure ONNX runtime for Cloudflare Workers. This ensures the
+// WebAssembly files are fetched from a remote CDN and avoids features
+// (like multi-threading/SIMD) that are not available in the Workers
+// runtime.
+env.backends.onnx.wasm.wasmPaths = `https://cdn.jsdelivr.net/npm/@xenova/transformers@${env.version}/dist/`;
+env.backends.onnx.wasm.numThreads = 1;
+env.backends.onnx.wasm.simd = false;
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
## Summary
- configure `@xenova/transformers` to load ONNX runtime wasm from CDN
- disable SIMD and multi-threading for compatibility with Cloudflare Workers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa17dc57ec83259145811c918f2737