### PR TITLE
fix(worker): Correct wrangler config for chatbot

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,9 +1,9 @@
 name = "repo-chat-api"
 main = "worker/worker.js"
-compatibility_date = "2025-08-23"
+compatibility_date = "2024-03-14"
 
 [vars]
 VECTORS_URL = "https://avinash040.github.io/Home/data/vectors.json"
-GEMINI_MODEL = "gemini-2.5-flash"
+GEMINI_MODEL = "gemini-1.5-flash-latest"
 TOP_K = "5"
 MAX_CONTEXT_CHARS = "6000"


### PR DESCRIPTION
The chatbot was failing due to a configuration issue in `wrangler.toml`.

- The `compatibility_date` was set to a future date, which can cause unpredictable behavior with the Cloudflare Workers runtime. This has been updated to a recent, stable date.
- The `GEMINI_MODEL` was set to `gemini-2.5-flash`. While this is a valid model, it might be in a preview or restricted access state. Switched to `gemini-1.5-flash-latest` for better stability and wider availability.