### PR TITLE
Fix front-end chat request and response handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,13 +200,16 @@
         const res = await fetch(`${WORKER_URL}/api/chat`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message: text })
+          body: JSON.stringify({ prompt: text })
         });
         const data = await res.json();
-        if (data.answer) {
-          appendMessage('bot', data.answer);
+        const answer = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+        if (answer) {
+          appendMessage('bot', answer);
           if (data.sources) {
-            const src = data.sources.map(s => `${s.label} • ${s.path} (${s.score.toFixed(2)})`).join(', ');
+            const src = data.sources
+              .map(s => `${s.label} • ${s.path} (${s.score.toFixed(2)})`)
+              .join(', ');
             appendMessage('bot', `Sources: ${src}`, 'sources');
           }
         } else if (data.error) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains the source for my personal website. The site highlights my professional experience, projects and links to my resume.",
   "main": "script.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/worker/worker.test.js
+++ b/worker/worker.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import worker from './worker.js';
+
+test('chat worker proxies prompt to Gemini API', async () => {
+  const fakeResponse = { candidates: [ { content: { parts: [ { text: 'Hello' } ] } } ] };
+  const fakeFetch = async (url, options) => {
+    assert.equal(options.method, 'POST');
+    return new Response(JSON.stringify(fakeResponse), {
+      status: 200,
+      headers: { 'content-type': 'application/json' }
+    });
+  };
+
+  const originalFetch = global.fetch;
+  global.fetch = fakeFetch;
+  try {
+    const request = new Request('https://example.com/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Hi' })
+    });
+    const env = { GEMINI_API_KEY: 'test-key' };
+    const res = await worker.fetch(request, env);
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.deepEqual(data, fakeResponse);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- send `prompt` field when calling chat worker
- parse Gemini API `candidates` to display bot response
- add Node-based test verifying worker proxy functionality

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd38781f8832592a86753c4c83232