### PR TITLE
feat: add repo-aware chat retrieval

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1,3 +1,17 @@
+import vectors from "../data/vectors.json" assert { type: "json" };
+
+function cosineSimilarity(a, b) {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -22,6 +36,39 @@ export default {
       }
       const prompt = body?.prompt ?? "Say hello and confirm the proxy works.";
 
+      let context = "";
+      try {
+        const embedRes = await fetch(
+          "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-goog-api-key": env.GEMINI_API_KEY,
+            },
+            body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
+          }
+        );
+        const embedData = await embedRes.json();
+        const query = embedData.embedding?.values || [];
+        const scored = vectors
+          .map((v) => ({
+            text: v.text,
+            score: cosineSimilarity(query, v.embedding),
+          }))
+          .sort((a, b) => b.score - a.score)
+          .slice(0, 3);
+        context = scored.map((s) => s.text).join("\n\n");
+      } catch {
+        // ignore retrieval errors and fall back to no context
+      }
+
+      const parts = [];
+      if (context) {
+        parts.push({ text: context });
+      }
+      parts.push({ text: prompt });
+
       const res = await fetch(
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
         {
@@ -31,7 +78,7 @@ export default {
             "x-goog-api-key": env.GEMINI_API_KEY,
           },
           body: JSON.stringify({
-            contents: [{ parts: [{ text: prompt }] }],
+            contents: [{ parts }],
           }),
         }
       );

--- a/worker/worker.test.js
+++ b/worker/worker.test.js
@@ -1,15 +1,29 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import worker from './worker.js';
+import vectors from '../data/vectors.json' assert { type: 'json' };
 
-test('chat worker proxies prompt to Gemini API', async () => {
+test('chat worker performs retrieval and forwards context', async () => {
+  const fakeEmbedding = { embedding: { values: vectors[0].embedding } };
   const fakeResponse = { candidates: [ { content: { parts: [ { text: 'Hello' } ] } } ] };
+  const calls = [];
   const fakeFetch = async (url, options) => {
-    assert.equal(options.method, 'POST');
-    return new Response(JSON.stringify(fakeResponse), {
-      status: 200,
-      headers: { 'content-type': 'application/json' }
-    });
+    calls.push({ url, options });
+    if (url.includes(':embedContent')) {
+      return new Response(JSON.stringify(fakeEmbedding), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      });
+    }
+    if (url.includes(':generateContent')) {
+      const body = JSON.parse(options.body);
+      assert.ok(body.contents[0].parts[0].text.includes('Avinash Kothapalli - Personal Website'));
+      return new Response(JSON.stringify(fakeResponse), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      });
+    }
+    throw new Error('Unexpected fetch: ' + url);
   };
 
   const originalFetch = global.fetch;
@@ -25,6 +39,7 @@ test('chat worker proxies prompt to Gemini API', async () => {
     assert.equal(res.status, 200);
     const data = await res.json();
     assert.deepEqual(data, fakeResponse);
+    assert.equal(calls.length, 2);
   } finally {
     global.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- load repo embeddings and compute cosine similarity for incoming queries
- prepend top-matching repo text to Gemini chat requests
- test retrieval logic to ensure repo context is forwarded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd80543f48325ab08d960bbc2c436