### PR TITLE
chore: index HTML content in RAG build workflow

### DIFF
--- a/.github/workflows/build-rag-index.yml
+++ b/.github/workflows/build-rag-index.yml
@@ -16,12 +16,12 @@ jobs:
         docs/**/*.md
         **/*.md
         **/*.txt
+        **/*.html
       EXCLUDE_GLOBS: |
         **/node_modules/**
         **/dist/**
         **/*.png
         **/*.jpg
-        **/*.pdf
         **/.git/**
         **/*.min.js
       CHUNK_CHARS: 1400


### PR DESCRIPTION
## Summary
- include HTML files when building RAG index
- allow PDFs to be considered by removing exclusion rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abdd25e5b08325a6683b3521794c7a