### PR TITLE
Improve RAG coverage and add first-person responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This repository contains the source for my personal website. The site highlights my professional experience, projects and links to my resume.",
   "main": "script.js",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "build:vectors": "node scripts/build-vectors.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/build-vectors.mjs
+++ b/scripts/build-vectors.mjs
@@ -1,0 +1,49 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const EMBED_URL = 'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent';
+const apiKey = process.env.GEMINI_API_KEY;
+if (!apiKey) {
+  console.error('GEMINI_API_KEY is required');
+  process.exit(1);
+}
+
+async function getFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'data') {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await getFiles(full));
+    } else if (entry.name.endsWith('.html') || entry.name.endsWith('.md')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const root = process.cwd();
+const files = await getFiles(root);
+const vectors = [];
+for (const file of files) {
+  const text = await fs.readFile(file, 'utf8');
+  const res = await fetch(EMBED_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-goog-api-key': apiKey,
+    },
+    body: JSON.stringify({ contents: [{ parts: [{ text }] }] }),
+  });
+  const data = await res.json();
+  const embedding = data.embedding?.values ?? [];
+  const id = crypto.createHash('sha256').update(text).digest('hex');
+  vectors.push({ id, text, source: path.relative(root, file), embedding });
+}
+
+await fs.mkdir(path.join(root, 'data'), { recursive: true });
+await fs.writeFile(path.join(root, 'data', 'vectors.json'), JSON.stringify(vectors, null, 2));

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -67,7 +67,10 @@ export default {
         // ignore retrieval errors and fall back to no context
       }
 
-      const parts = [];
+      const instruction =
+        "You are answering on behalf of Avinash Kothapalli. " +
+        "Speak in the first person when describing his work experience.";
+      const parts = [{ text: instruction }];
       if (context) {
         parts.push({ text: context });
       }

--- a/worker/worker.test.js
+++ b/worker/worker.test.js
@@ -17,7 +17,10 @@ test('chat worker performs retrieval and forwards context', async () => {
     }
     if (url.includes(':generateContent')) {
       const body = JSON.parse(options.body);
+      assert.equal(body.contents[0].parts.length, 3);
       assert.ok(body.contents[0].parts[0].text.includes('Avinash Kothapalli'));
+      assert.ok(body.contents[0].parts[1].text.includes('Avinash Kothapalli'));
+      assert.equal(body.contents[0].parts[2].text, 'Hi');
       return new Response(JSON.stringify(fakeResponse), {
         status: 200,
         headers: { 'content-type': 'application/json' }


### PR DESCRIPTION
## Summary
- Add script to embed every HTML and Markdown page so the vector index covers the whole site
- Instruct Gemini to answer in Avinash's first person voice for work experience queries
- Extend tests for new instruction and context behavior

## Testing
- `npm test`
- `npm run build:vectors` *(fails: GEMINI_API_KEY is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ac704a1724832594b67fd641c483c5