### PR TITLE
Ensure per-experience tagging for vector search

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 
     <section id="experience">
       <h2>🎯 Professional Experience</h2>
-      <article>
+      <article id="senior-delivery-software-engineer-nokia">
         <h3>Senior Delivery Software Engineer – Nokia</h3>
         <p><em>04/2020 – Present | Ottawa, Canada</em></p>
         <ul>
@@ -67,7 +67,7 @@
           <li>Worked on autonomous networks and intent-based service deployment using Pydantic and LLaMA AI models.</li>
         </ul>
       </article>
-      <article>
+      <article id="member-of-technical-staff-ii-vmware">
         <h3>Member of Technical Staff – II – VMware</h3>
         <p><em>07/2016 – 04/2020 | Ottawa, Canada</em></p>
         <ul>
@@ -91,7 +91,7 @@
           <li><a href="vmware/jenkins.html">Jenkins</a></li>
         </ul>
       </article>
-      <article>
+      <article id="software-engineer-cisco-systems">
         <h3>Software Engineer – Cisco Systems</h3>
         <p><em>07/2012 – 06/2016 | Ottawa, Canada</em></p>
         <ul>
@@ -103,7 +103,7 @@
           <li>Maintained private cloud infrastructure with Cisco UCS servers, vSphere, and OpenStack.</li>
         </ul>
       </article>
-      <article>
+      <article id="software-designer-protocol-associate-co-op-blackberry">
         <h3>Software Designer / Protocol Associate (Co-op) – Blackberry</h3>
         <p><em>05/2010 – 09/2011 | Ottawa, Canada</em></p>
         <ul>

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -66,12 +66,9 @@ export default {
         const unique = [];
         const seen = new Set();
         for (const s of scored) {
-          const company = s.source.includes("#")
-            ? s.source.split("#")[1].split("/")[0]
-            : s.source.split("/")[0];
-          if (!seen.has(company)) {
+          if (!seen.has(s.source)) {
             unique.push(s);
-            seen.add(company);
+            seen.add(s.source);
           }
           if (unique.length === 3) break;
         }


### PR DESCRIPTION
## Summary
- add stable `id` anchors to each work experience article in `index.html`
- deduplicate retrieval results by full source path instead of coarse company name

## Testing
- `npm test`
- `npm run build:vectors` *(fails: GEMINI_API_KEY is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ad03ddebe88325aa9099faaa540a9b