### PR TITLE
Expand RAG retrieval context

### DIFF
--- a/worker/worker.test.js
+++ b/worker/worker.test.js
@@ -41,7 +41,8 @@ test('chat worker performs retrieval and forwards context', async () => {
     const res = await worker.fetch(request, env);
     assert.equal(res.status, 200);
     const data = await res.json();
-    assert.deepEqual(data, fakeResponse);
+    assert.deepEqual(data.candidates, fakeResponse.candidates);
+    assert.equal(data.sources.length, 5);
     assert.equal(calls.length, 2);
   } finally {
     global.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- Retrieve top 5 vector matches instead of unique top 3 to surface more work experiences
- Include source paths and scores in API responses for debugging
- Update tests for new retrieval behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad11e025c8832590f2bd86f02311d8