### PR TITLE
Adjust chat background image framing

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
       background-color: #fafafa;
       background-image: url('IMG_7422.jpeg');
       background-size: cover;
-      background-position: center;
+      /* Shift image upward to better frame the subject's face and hoodie text */
+      background-position: center 20%;
       background-repeat: no-repeat;
     }
     .message { padding: .5rem; border-radius: 4px; margin-bottom: .5rem; }


### PR DESCRIPTION
## Summary
- Reposition chat background image upward to better feature the subject's face and hoodie text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6d94a2f4832584ad74ec7e875ec4