### PR TITLE
Rework layout to emphasize chatbot

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,9 @@
   <title>Avinash Kothapalli</title>
   <link rel="stylesheet" href="styles.css">
   <style>
-    #chat-container { max-width: 600px; margin: 2rem auto; }
     #chat-log {
       border: 1px solid #ccc;
       padding: 1rem;
-      height: 300px;
       overflow-y: auto;
       background-color: #fafafa;
       background-image: url('IMG_7422.jpeg');
@@ -43,9 +41,10 @@
     </nav>
   </header>
 
-  <main>
-    <section id="chat">
+  <main id="layout">
+    <section id="chat" class="highlight">
       <h2>Chat</h2>
+      <p class="chat-intro">Use the chatbot to ask about my experience, skills, or projects.</p>
       <div id="chat-container">
         <div id="chat-log"></div>
         <form id="chat-form">
@@ -55,6 +54,7 @@
       </div>
     </section>
 
+    <div id="info">
     <section id="about">
       <h2>About</h2>
       <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
@@ -188,6 +188,7 @@
       <button id="resume-toggle">Show Resume</button>
       <iframe id="resume-frame" src="Resume_AvinashKothapalli.pdf"></iframe>
     </section>
+    </div>
   </main>
 
   <footer>

--- a/styles.css
+++ b/styles.css
@@ -34,8 +34,50 @@ nav button {
 
 section {
   padding: 20px;
-  max-width: 900px;
-  margin: auto;
+}
+
+main#layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+#info {
+  order: 1;
+  flex: 1;
+}
+
+#chat {
+  order: 2;
+  flex: 1.2;
+}
+
+#chat.highlight {
+  border: 2px solid #4caf50;
+  border-radius: 8px;
+  padding: 20px;
+  background: #fefefe;
+  box-shadow: 0 0 10px rgba(76, 175, 80, 0.3);
+}
+
+.chat-intro {
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+#chat-container {
+  width: 100%;
+  margin: 0;
+}
+
+#chat-log {
+  height: 400px;
+}
+
+@media (max-width: 800px) {
+  main#layout {
+    flex-direction: column;
+  }
 }
 
 #projects-list .project {


### PR DESCRIPTION
## Summary
- Rearranged homepage into a two-column flex layout with personal info on the left and a highlighted chatbot on the right.
- Enlarged chat area and added introductory text to guide new users.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6ef12e248325ae8ae41b4cba6e92