### PR TITLE
Display chat section above content on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -209,6 +209,14 @@ footer {
     flex-direction: column;
   }
 
+  #chat {
+    order: 1;
+  }
+
+  #info {
+    order: 2;
+  }
+
   nav {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Ensure chat section appears before other page sections on small screens by overriding flex order in mobile styles.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba75682c4483258949568c4c5e858e