### PR TITLE
Improve RAG vector build for unlabeled sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ The chat endpoint retrieves context from embeddings stored in `data/vectors.json
 npm run build:vectors
 ```
 
-The build script now breaks large HTML files into article-sized chunks, ensuring details from every work experience are available for retrieval. Set `GEMINI_API_KEY` in your environment before running the command.
+The build script now breaks large HTML files into article-sized chunks and automatically slugs section headings when IDs are missing. This ensures details from every work experience across the site are indexed for retrieval. Set `GEMINI_API_KEY` in your environment before running the command.

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -60,13 +60,18 @@ export default {
           .map((v) => ({
             text: v.text,
             source: v.source,
+            label: v.label,
             score: cosineSimilarity(query, v.embedding),
           }))
           .sort((a, b) => b.score - a.score);
 
         const top = scored.slice(0, 5);
         context = top.map((s) => s.text).join("\n\n");
-        sources = top.map((s) => ({ path: s.source, score: s.score }));
+        sources = top.map((s) => ({
+          path: s.source,
+          label: s.label || s.source,
+          score: s.score,
+        }));
       } catch {
         // ignore retrieval errors and fall back to no context
       }


### PR DESCRIPTION
## Summary
- Handle HTML sections without IDs by slugifying their headings during vector index generation
- Include section labels in embeddings and propagate them through the worker response for clearer source citations
- Document new vector build behavior in README

## Testing
- `npm test`
- `npm run build:vectors` *(fails: GEMINI_API_KEY is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c3211ddd748325979fbe5d62703d8e