### PR TITLE
Align chat and about sections in layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,25 +26,27 @@
   </header>
 
   <main id="layout" class="container">
-    <section id="chat" class="highlight">
-      <h2>Chat</h2>
-      <p class="chat-intro">Use the chatbot to ask about my experience, skills, or projects.</p>
-      <div id="chat-container">
-        <div id="chat-log"></div>
-        <form id="chat-form">
-          <input id="chat-input" type="text" placeholder="Ask a question..." />
-          <button type="submit">Send</button>
-        </form>
-      </div>
-    </section>
+    <div id="top">
+      <section id="chat" class="highlight">
+        <h2>Chat</h2>
+        <p class="chat-intro">Use the chatbot to ask about my experience, skills, or projects.</p>
+        <div id="chat-container">
+          <div id="chat-log"></div>
+          <form id="chat-form">
+            <input id="chat-input" type="text" placeholder="Ask a question..." />
+            <button type="submit">Send</button>
+          </form>
+        </div>
+      </section>
+
+      <section id="about">
+        <h2>About</h2>
+        <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
+        <p>Recently I have focused on applying AI and LLMs in the networking domain, building tools that streamline operations and enable autonomous networks.</p>
+      </section>
+    </div>
 
     <div id="info">
-    <section id="about">
-      <h2>About</h2>
-      <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
-      <p>Recently I have focused on applying AI and LLMs in the networking domain, building tools that streamline operations and enable autonomous networks.</p>
-    </section>
-
     <section id="experience">
       <h2>🎯 Professional Experience</h2>
       <article id="senior-delivery-software-engineer-nokia">

--- a/styles.css
+++ b/styles.css
@@ -83,10 +83,17 @@ nav button {
 }
 
 main#layout {
+  padding: 2rem 0;
+}
+
+#top {
   display: flex;
   align-items: flex-start;
   gap: 2rem;
-  padding: 2rem 0;
+}
+
+#top > section {
+  flex: 1;
 }
 
 section {
@@ -98,13 +105,7 @@ section {
 }
 
 #info {
-  order: 1;
-  flex: 1;
-}
-
-#chat {
-  order: 2;
-  flex: 1.2;
+  margin-top: 2rem;
 }
 
 #chat.highlight {
@@ -205,16 +206,8 @@ footer {
 }
 
 @media (max-width: 800px) {
-  main#layout {
+  #top {
     flex-direction: column;
-  }
-
-  #chat {
-    order: 1;
-  }
-
-  #info {
-    order: 2;
   }
 
   nav {


### PR DESCRIPTION
## Summary
- Display chat and about panels side-by-side using a new flex container
- Move remaining sections below the top panels for clearer hierarchy
- Adjust responsive styles to stack chat and about vertically on narrow screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3875f25648325973f0a6c8287baeb