### PR TITLE
Lay out chat and about sections side by side

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,25 +26,23 @@
   </header>
 
   <main id="layout" class="container">
-    <div id="top">
-      <section id="chat" class="highlight">
-        <h2>Chat</h2>
-        <p class="chat-intro">Use the chatbot to ask about my experience, skills, or projects.</p>
-        <div id="chat-container">
-          <div id="chat-log"></div>
-          <form id="chat-form">
-            <input id="chat-input" type="text" placeholder="Ask a question..." />
-            <button type="submit">Send</button>
-          </form>
-        </div>
-      </section>
+    <section id="chat" class="highlight">
+      <h2>Chat</h2>
+      <p class="chat-intro">Use the chatbot to ask about my experience, skills, or projects.</p>
+      <div id="chat-container">
+        <div id="chat-log"></div>
+        <form id="chat-form">
+          <input id="chat-input" type="text" placeholder="Ask a question..." />
+          <button type="submit">Send</button>
+        </form>
+      </div>
+    </section>
 
-      <section id="about">
-        <h2>About</h2>
-        <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
-        <p>Recently I have focused on applying AI and LLMs in the networking domain, building tools that streamline operations and enable autonomous networks.</p>
-      </section>
-    </div>
+    <section id="about">
+      <h2>About</h2>
+      <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
+      <p>Recently I have focused on applying AI and LLMs in the networking domain, building tools that streamline operations and enable autonomous networks.</p>
+    </section>
 
     <div id="info">
     <section id="experience">

--- a/styles.css
+++ b/styles.css
@@ -84,16 +84,24 @@ nav button {
 
 main#layout {
   padding: 2rem 0;
-}
-
-#top {
-  display: flex;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas:
+    "chat about"
+    "info info";
   gap: 2rem;
 }
 
-#top > section {
-  flex: 1;
+#chat {
+  grid-area: chat;
+}
+
+#about {
+  grid-area: about;
+}
+
+#info {
+  grid-area: info;
 }
 
 section {
@@ -102,10 +110,6 @@ section {
   border-radius: 8px;
   padding: 1.5rem;
   margin-bottom: 2rem;
-}
-
-#info {
-  margin-top: 2rem;
 }
 
 #chat.highlight {
@@ -206,8 +210,12 @@ footer {
 }
 
 @media (max-width: 800px) {
-  #top {
-    flex-direction: column;
+  main#layout {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "chat"
+      "about"
+      "info";
   }
 
   nav {


### PR DESCRIPTION
## Summary
- Replace wrapper div with grid-based layout placing chat and about sections in separate columns.
- Use CSS grid to span remaining content across both columns and keep responsive stacking on small screens.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c388b340d88325afce95beecb05b98