### PR TITLE
Use Gemini generated image for chat background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -132,7 +132,7 @@ section {
   height: 400px;
   overflow-y: auto;
   background-color: var(--color-card-bg);
-  background-image: url('6B7FC679-8A34-40B4-B616-C6F69C3047D0_1_201_a.jpeg');
+  background-image: url('Gemini_Generated_Image.png');
   background-size: cover;
   background-position: center 20%;
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- replace chat log's default background with `Gemini_Generated_Image.png`

## Testing
- `npm test`
- `npm run build:vectors` *(fails: GEMINI_API_KEY is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c7134e0b248325aa0532bf75a94b58