### PR TITLE
Adjust chat background image position

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -134,7 +134,7 @@ section {
   background-color: var(--color-card-bg);
   background-image: url('Gemini_Generated_Image.png');
   background-size: cover;
-  background-position: center 20%;
+  background-position: center 45%;
   background-repeat: no-repeat;
   border-radius: 8px;
 }


### PR DESCRIPTION
## Summary
- move the chat panel background image 25% upward for better framing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c717129b188325846fd0531410df0b