### PR TITLE
Refresh About section content and layout order

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,14 @@
   </header>
 
   <main id="layout" class="container">
+    <section id="about">
+      <h2>About Me</h2>
+      <p>I&rsquo;m a Senior Software Developer with a focus on Autonomous Networks, AI Agents, and Software Tools. Over the years I&rsquo;ve worked across embedded systems, cloud platforms, and large-scale automation&mdash;always with the goal of making complex systems more reliable and intelligent.</p>
+      <p>At Nokia, I work on intent-based automation and service fulfillment, designing APIs and workflows with YANG, REST, Pydantic, and LLaMA, while deploying resilient platforms with Docker, Kubernetes, OpenStack, and OpenSearch. Before that, at VMware, I built alerting engines and data collectors for the SMARTS platform and Velocloud SD-WAN, moving from Kafka Streams to Flink, creating simulators and microservices, and running everything on Kubernetes and AWS with CI/CD pipelines.</p>
+      <p>Earlier in my career at Cisco and BlackBerry, I focused on embedded software and networking protocols, working on firmware, protocol stacks, and embedded Linux/RTOS environments. Those roles gave me a solid foundation in performance, reliability, and interoperability at the system level&mdash;experience I still draw on when building today&rsquo;s distributed and automated platforms.</p>
+      <p>Outside of work, I tinker with robotics, VR/AR, Raspberry Pi, and ROS/Gazebo.</p>
+    </section>
+
     <section id="chat" class="highlight">
       <h2>Chat</h2>
       <p class="chat-intro">Use the chatbot to ask about my experience, skills, or projects.</p>
@@ -36,12 +44,6 @@
           <button type="submit">Send</button>
         </form>
       </div>
-    </section>
-
-    <section id="about">
-      <h2>About</h2>
-      <p>I am a senior delivery software engineer at Nokia with experience developing custom network software solutions for service providers and enterprises. I create API interfaces for service provisioning, lifecycle management, and automation using YANG models and REST.</p>
-      <p>Recently I have focused on applying AI and LLMs in the networking domain, building tools that streamline operations and enable autonomous networks.</p>
     </section>
 
     <div id="info">


### PR DESCRIPTION
## Summary
- update the About section with new narrative detailing autonomous networks, AI, and tooling experience
- reorder the About section ahead of the chat widget to highlight the refreshed biography

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca2215d6ac83259e0bdde0450de550