### PR TITLE
Swap chat and about section layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -87,7 +87,7 @@ main#layout {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-areas:
-    "chat about"
+    "about chat"
     "info info";
   gap: 2rem;
 }
@@ -213,8 +213,8 @@ footer {
   main#layout {
     grid-template-columns: 1fr;
     grid-template-areas:
-      "chat"
       "about"
+      "chat"
       "info";
   }
 


### PR DESCRIPTION
## Summary
- update the grid layout to position the About section before the Chat module on desktop and mobile widths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad6a1478083258ddf222cf81ee7f3